### PR TITLE
ci: add github action for semantic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Pre-requisities
+      run: sudo npm install -g vsce
+    - run: npm install
+
+    - name: Update version and changelog
+      run: npx semantic-release --dry-run
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Package VSIX
+      run: vsce package
+    - uses: actions/upload-artifact@v2
+      with:
+        name: VSIX
+        path: "*.vsix"
+    - name: Commit new version and changelog
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "github-actions"
+        git add package.json CHANGELOG.md
+        git commit -m "chore: Update version & changelog. [skip ci]"
+    - name: Push changes
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Rename VSIX
+      run: mv *.vsix code4z.vsix
+    - name: Run semantic-release
+      run: npx semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish
+      run: vsce publish
+      env:
+        VSCE_PAT: $

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 *.vsix
+
+node_modules

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,16 @@
+branches:
+  - master
+  - name: release-+([0-9]).+([0-9]).+([0-9])
+    prerelease: beta
+ci: true
+tagFormat: ${version}
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/exec"
+    - generateNotesCmd: sh prepare_release.sh ${nextRelease.version} ${branch.name} "${nextRelease.notes}" ${lastRelease.version} ${Date.now()}
+  - - "@semantic-release/github"
+    - assets:
+      - path: "code4z.vsix"
+        label: "code4z-${nextRelease.version}.vsix"
+        name: "code4z-${nextRelease.version}.vsix"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,2 @@
+.github
+.gitignore

--- a/package.json
+++ b/package.json
@@ -13,11 +13,31 @@
 		"vscode": "^1.10.0"
 	},
 	"keywords": [
-		"z/OS", "zos", "lsp", "assembler", "hlasm", "zowe", "cobol", "dataset", "mainframe", "explorer", "endevor", "jcl", "uss", "debugger", "ca-intertest", "cics"
+		"z/OS",
+		"zos",
+		"lsp",
+		"assembler",
+		"hlasm",
+		"zowe",
+		"cobol",
+		"dataset",
+		"mainframe",
+		"explorer",
+		"endevor",
+		"jcl",
+		"uss",
+		"debugger",
+		"ca-intertest",
+		"cics"
 	],
 	"categories": [
 		"Extension Packs"
 	],
+	"devDependencies": {
+		"@semantic-release/changelog": "^5.0.0",
+		"@semantic-release/exec": "^5.0.0",
+		"semantic-release": "^17.0.7"
+	},
 	"extensionPack": [
 		"broadcomMFD.cobol-language-support",
 		"Zowe.vscode-extension-for-zowe",

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -1,0 +1,12 @@
+set -e
+set -x
+VERSION=$1
+CURRENT_BRANCH=$2
+RELEASE_NOTES=$3
+OLD_VERSION=$4
+DATE=$5
+
+{ printf "%s" "$RELEASE_NOTES"; cat CHANGELOG.md; } > tmp.md
+mv tmp.md CHANGELOG.md
+
+sed -i 's/"version": ".*"/"version": "'$VERSION'"/g' package.json


### PR DESCRIPTION
When a commit is pushed to master, semantic release is run in Github Actions with the following steps:
1. Updates version in package.json
2. Analyzes commits since the last release and generates changelog. Only commits with the fix and feat prefixes are taken into consideration
3. Pushes the new version and package.json
4. Creates the code4z-<version>.vsix file.
5. Creates Github release with the vsix file as an asset
6. Publishes the vsix using vsce publish command. (this is not done, yet, we need to create secret with Personal Access Token(PAT) to access BroadcomMFD publisher account)