### PR TITLE
Specify Java prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ With the Code4z extension pack you can:
 
 ## Prerequisites
 
-* Java installed on your machine.
+* Java JRE version 11 or higher with the PATH variable correctly configured.
 * Individual extension prerequisites are detailed in the individual readme files linked below.
 
 ## [COBOL Language Support](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.cobol-language-support)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ With the Code4z extension pack you can:
 
 ## Prerequisites
 
-* Java JRE version 11 or higher with the PATH variable correctly configured.
+* Java JRE version 11 or higher with the PATH variable correctly configured. For more information, see the [Java documentation](https://www.java.com/en/download/help/path.xml).
 * Individual extension prerequisites are detailed in the individual readme files linked below.
 
 ## [COBOL Language Support](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.cobol-language-support)


### PR DESCRIPTION
We got a comment that we should be more specific about the Java prerequisite - I've therefore updated it to JRE v11 or higher with the path variable configured, to encompass all the requirements of the individual extensions.