### PR TITLE
Downgrade vsce in GH Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,16 +13,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Pre-requisities
-      run: sudo npm install -g vsce
-    - run: npm install
+    - name: Install dependencies
+      run: npm install
 
     - name: Update version and changelog
       run: npx semantic-release --dry-run
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Package VSIX
-      run: vsce package
+      run: npx vsce package
     - uses: actions/upload-artifact@v2
       with:
         name: VSIX
@@ -44,6 +43,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish
-      run: vsce publish
+      run: npx vsce publish
       env:
         VSCE_PAT: $


### PR DESCRIPTION
The latest vsce v2 is not compatible with the current environment.