### PR TITLE
Code4z Foundation 2.2 expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
-# Code4z
-
+<div align="center">
+  
 [![License](https://img.shields.io/badge/license-BROADCOM-brightgreen)](https://github.com/BroadcomMFD/code4z/blob/master/LICENSE)
+[![slack](https://img.shields.io/badge/chat-on%20Slack-blue)](https://join.slack.com/t/che4z/shared_invite/zt-37ewynplx-wCoabaIDxN6Ofm4_XBinZA)
+[![Code4z](https://img.shields.io/badge/Code4z-marketplace-cc092f)](https://marketplace.visualstudio.com/search?term=code4z&target=VSCode)
 
-Code4z is an all-in-one VS Code extension pack for mainframe users working with z/OS. Code4z provides language support for COBOL and High Level Assembler for z/OS and graphical visualization of COBOL applications. The pack also includes data editing and file management tools, Explorer for Endevor, and extensions for interactive debugging, macro tracing, and abend analysis. Code4z is free to install and use.
+</div>
 
-Code4z is compatible with Microsoft Visual Studio Code and Github Codespaces.
+# Code4z Foundation
+
+Code4z Foundation is an all-in-one VS Code extension pack for mainframe users working with z/OS. Code4z Foundation provides language support for several common z/OS programming languages and graphical visualization of COBOL applications. The pack also includes data editing and file management tools, Explorer for Endevor, and extensions for interactive debugging, macro tracing, and abend analysis. Code4z Foundation is free to install and use.
+
+The Code4z Foundation pack is compatible with Microsoft Visual Studio Code and Github Codespaces.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/BroadcomMFD/code4z/master/extensions4.png" alt="Code4z Extensions: Abend Analyzer for Mainframe, COBOL Control Flow, COBOL Language Support, Data Editor for Mainframe, Debugger for Mainframe, Explorer for Endevor, HLASM Language Support and Zowe Explorer" />
-
-<a href="https://www.openmainframeproject.org/all-projects/zowe/conformance"><img alt="This extension is Zowe v3 conformant" src="https://artwork.openmainframeproject.org/other/zowe-conformant/zowev3/explorer-vs-code/color/zowe-conformant-zowev3-explorer-vs-code-color.png"  width=260 height=195 /></a>
+  <img src="https://raw.githubusercontent.com/BroadcomMFD/code4z/master/foundationpack.png" alt="Code4z Foundation Extensions: Abend Analyzer for Mainframe, COBOL Control Flow, COBOL Language Support, Data Editor for Mainframe, Debugger for Mainframe, Explorer for Endevor, HLASM Language Support, JCL Language Support, PL/I Language Support and Zowe Explorer" />
 </div>
 
 ## How Does It Work?
 
-The Code4z extension pack simplifies your common workflows and enables you to work with COBOL and HLASM code in the same way you work with other languages in Visual Studio Code. The pack provides a modern mainframe programming experience and includes the following features:
+The Code4z Foundation pack simplifies your common workflows and enables you to work with COBOL, HLASM, JCL, and PL/I code in the same way you work with other languages in Visual Studio Code. The pack provides a modern mainframe programming experience and includes the following features:
 
-- Language support for IBM Enterprise COBOL 6.0 and high-level assembler language
+- Language support for IBM Enterprise COBOL, HLASM, JCL, and PL/I.
 - Data editing and file management of mainframe data sets
 - Testing tools for CICS and Batch programs
 - Source code management integrated with Endevor
@@ -24,7 +28,7 @@ The Code4z extension pack simplifies your common workflows and enables you to wo
 
 ## Extensions
 
-Code4z contains the following extensions:
+Code4z Foundation contains the following extensions:
 - [Abend Analyzer for Mainframe](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.abend-analyzer)
   - Enables you to view abend reports and symbolic data in your IDE.
 - [COBOL Control Flow](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.ccf)
@@ -39,11 +43,15 @@ Code4z contains the following extensions:
   - Modernizes the way that you interact with Endevor inventory locations and elements.
 - [HLASM Language Support](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.hlasm-language-support)
   - Provides autocomplete, highlighting, browsing, and diagnostics for High Level Assembler code.
+- [JCL Language Support](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.jcl-language-support)
+  - Provides rich language support and snippets for JCL code.
+- [PL/I Language Support](https://marketplace.visualstudio.com/items?itemName=broadcomMFD.pli-language-support)
+  - Provides rich language support for PL/I code and include files.
 - [Zowe Explorer](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe)
   - Streamlines interaction with mainframe data sets, USS files, and jobs.
 
 ## Support
 
-**Code4z product documentation is available on [Techdocs](https://techdocs.broadcom.com/code4z)**.
+**Product documentation for Code4z Foundation is available on [Techdocs](https://techdocs.broadcom.com/code4z)**.
 
-For an interactive overview of Code4z, see the [Code4z Developer Cockpit](https://mainframe.broadcom.com/code4z-developer-cockpit).
+For an interactive overview of the Code4z Foundation pack, see the [Code4z Developer Cockpit](https://mainframe.broadcom.com/code4z-developer-cockpit).


### PR DESCRIPTION
- add JCL and PL/I Language Support
- add code4z marketplace and slack badges to the top, put badges centred
- rename to Code4z Foundation
- remove Zowe badge, PL/I LS is not conformant therefore neither is the pack currently